### PR TITLE
Fix new-user initialization for Firestore

### DIFF
--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -166,6 +166,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
                     // Data is null, probably a new user, so create their data
                     const guestUserShell = firebaseUser.isAnonymous ? GUEST_USER : undefined;
                     await firebaseService.createInitialUserData(firebaseUser, guestUserShell);
+                    await firebaseService.updateUserOnlineStatus(firebaseUser.uid, 'online');
                     // The listener will be triggered again with the new data
                 }
             });


### PR DESCRIPTION
## Summary
- don't create partial user doc when signing in for the first time
- fall back to `set` when updating a missing doc
- update online status once user doc is initialized

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883848588a48324bca27a894deb8069